### PR TITLE
Try to create cache directory on each CLI call

### DIFF
--- a/entities_service/cli/_utils/global_settings.py
+++ b/entities_service/cli/_utils/global_settings.py
@@ -14,7 +14,7 @@ except ImportError as exc:  # pragma: no cover
     ) from exc
 
 from entities_service import __version__
-from entities_service.cli._utils.generics import print
+from entities_service.cli._utils.generics import CACHE_DIRECTORY, ERROR_CONSOLE, print
 from entities_service.service.config import CONFIG
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -69,6 +69,19 @@ def global_options(
         rich_help_panel="Global options",
     ),
 ) -> None:
-    """Global options for the CLI."""
+    """Global options for the CLI.
+
+    This function is also used to run initial setup for the CLI.
+    """
     if dotenv_path:
         CONTEXT["dotenv_path"] = dotenv_path
+
+    # Initialize the cache directory
+    try:
+        CACHE_DIRECTORY.mkdir(parents=True, exist_ok=True)
+    except PermissionError as exc:
+        ERROR_CONSOLE.print(
+            f"[bold red]Error[/bold red]: {CACHE_DIRECTORY} is not writable. "
+            "Please check your permissions."
+        )
+        raise typer.Exit(1) from exc

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -41,12 +41,12 @@ def config_app() -> Typer:
 @pytest.fixture()
 def tmp_cache_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Create a temporary cache directory."""
-    from entities_service.cli._utils import generics
+    from entities_service.cli._utils import generics, global_settings
 
     cache_dir = tmp_path / ".cache" / "entities-service"
-    cache_dir.mkdir(parents=True)
 
     monkeypatch.setattr(generics, "CACHE_DIRECTORY", cache_dir)
+    monkeypatch.setattr(global_settings, "CACHE_DIRECTORY", cache_dir)
 
     return cache_dir
 
@@ -67,7 +67,6 @@ def _function_specific_cli_cache_dir(
     from entities_service.cli._utils import generics
 
     cache = JsonTokenFileCache(str(tmp_cache_file))
-    cache.clear()
 
     monkeypatch.setattr(generics.OAuth2, "token_cache", cache)
 


### PR DESCRIPTION
Fixes #82 

As part of calling the CLI and loading/setting the global configuration options, the cache directory is created if it does not already exist.
If, for some reason, `PermissionError` is raised, i.e., if the user does not have the correct permissions to create folders in their own home folder, an appropriate error message will be written back to the user.