### PR TITLE
Unify entity version and name validation

### DIFF
--- a/entities_service/main.py
+++ b/entities_service/main.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Annotated
 from fastapi import FastAPI, HTTPException, Path, status
 
 from entities_service import __version__
-from entities_service.models import VersionedSOFTEntity
+from entities_service.models import SEMVER_REGEX, VersionedSOFTEntity
 from entities_service.service.backend import get_backend
 from entities_service.service.config import CONFIG
 from entities_service.service.logger import setup_logger
@@ -55,19 +55,6 @@ for router in get_routers():
     APP.include_router(router)
 
 
-SEMVER_REGEX = (
-    r"^(?P<major>0|[1-9]\d*)(?:\.(?P<minor>0|[1-9]\d*))?(?:\.(?P<patch>0|[1-9]\d*))?"
-    r"(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
-    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
-    r"(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
-)
-"""Semantic Versioning regular expression.
-
-Slightly changed version of the one found at https://semver.org.
-The changed bits pertain to `minor` and `patch`, which are now both optional.
-"""
-
-
 @APP.get(
     "/{version}/{name}",
     response_model=VersionedSOFTEntity,
@@ -90,7 +77,6 @@ async def get_entity(
         str,
         Path(
             title="Entity name",
-            pattern=r"(?i)^[A-Z]+$",
             description=(
                 "The name part is without any white space. It is conventionally "
                 "written in PascalCase."

--- a/entities_service/main.py
+++ b/entities_service/main.py
@@ -10,7 +10,11 @@ from typing import TYPE_CHECKING, Annotated
 from fastapi import FastAPI, HTTPException, Path, status
 
 from entities_service import __version__
-from entities_service.models import SEMVER_REGEX, VersionedSOFTEntity
+from entities_service.models import (
+    EntityNameType,
+    EntityVersionType,
+    VersionedSOFTEntity,
+)
 from entities_service.service.backend import get_backend
 from entities_service.service.config import CONFIG
 from entities_service.service.logger import setup_logger
@@ -63,10 +67,9 @@ for router in get_routers():
 )
 async def get_entity(
     version: Annotated[
-        str,
+        EntityVersionType,
         Path(
             title="Entity version",
-            pattern=SEMVER_REGEX,
             description=(
                 "The version part must be a semantic version, following the schema "
                 "laid out by SemVer.org."
@@ -74,7 +77,7 @@ async def get_entity(
         ),
     ],
     name: Annotated[
-        str,
+        EntityNameType,
         Path(
             title="Entity name",
             description=(

--- a/entities_service/models/__init__.py
+++ b/entities_service/models/__init__.py
@@ -6,7 +6,13 @@ from typing import TYPE_CHECKING, get_args, overload
 
 from pydantic import ValidationError
 
-from .soft5 import URI_REGEX, SOFT5Entity
+from .soft5 import (
+    SEMVER_REGEX,
+    URI_REGEX,
+    EntityNameType,
+    EntityVersionType,
+    SOFT5Entity,
+)
 from .soft7 import SOFT7Entity
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -14,6 +20,20 @@ if TYPE_CHECKING:  # pragma: no cover
 
 VersionedSOFTEntity = SOFT7Entity | SOFT5Entity
 SOFTModelTypes = (SOFT7Entity, SOFT5Entity)
+
+__all__ = (
+    "VersionedSOFTEntity",
+    "SOFTModelTypes",
+    "soft_entity",
+    "get_uri",
+    "get_version",
+    "get_updated_version",
+    "URI_REGEX",
+    "SEMVER_REGEX",
+    "soft_entity",
+    "EntityNameType",
+    "EntityVersionType",
+)
 
 
 @overload

--- a/entities_service/models/soft5.py
+++ b/entities_service/models/soft5.py
@@ -5,16 +5,91 @@ from __future__ import annotations
 import difflib
 import re
 from typing import Annotated, Any
+from urllib.parse import quote
 
-from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    Field,
+    TypeAdapter,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
+from pydantic.functional_validators import AfterValidator
 from pydantic.networks import AnyHttpUrl
 
 from entities_service.service.config import CONFIG
 
+SEMVER_REGEX = (
+    r"(?P<major>0|[1-9]\d*)(?:\.(?P<minor>0|[1-9]\d*))?(?:\.(?P<patch>0|[1-9]\d*))?"
+    r"(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    r"(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
+)
+"""Semantic Versioning regular expression.
+
+Slightly changed version of the one found at https://semver.org.
+The changed bits pertain to `minor` and `patch`, which are now both optional.
+"""
+
+NO_GROUPS_SEMVER_REGEX = (
+    r"(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*))?(?:\.(?:0|[1-9]\d*))?"
+    r"(?:-(?:(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    r"(?:\+(?:[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
+)
+"""Semantic Versioning regular expression.
+
+Slightly changed version of the one found at https://semver.org.
+The changed bits pertain to `minor` and `patch`, which are now both optional.
+
+This is the same as `SEMVER_REGEX`, but without the named groups.
+"""
+
 URI_REGEX = re.compile(
-    r"^(?P<namespace>https?://.+)/(?P<version>\d(?:\.\d+){0,2})/(?P<name>[^/#?]+)$"
+    rf"^(?P<namespace>https?://.+)/(?P<version>{NO_GROUPS_SEMVER_REGEX})/(?P<name>[^/#?]+)$"
 )
 """Regular expression to parse a SOFT entity URI."""
+
+
+def _disallowed_characters(value: str | None) -> str | None:
+    """Check that the value does not contain disallowed characters."""
+    if value is None:
+        return value
+
+    special_url_characters = ["/", "?", "#", "@", ":"]
+    if any(char in value for char in special_url_characters):
+        raise ValueError(
+            f"The value must not contain any of {special_url_characters} characters."
+        )
+    if " " in value:
+        raise ValueError("The value must not contain any spaces.")
+    return value
+
+
+def _ensure_url_encodeable(value: str | None) -> str | None:
+    """Ensure that the value is URL encodeable."""
+    if value is None:
+        return value
+
+    try:
+        quote(value)
+    except Exception as error:  # noqa: BLE001
+        raise ValueError(f"The value is not URL encodeable: {error}") from error
+    return value
+
+
+EntityVersionType = Annotated[
+    str | None,
+    Field(description="The version of the entity.", pattern=rf"^{SEMVER_REGEX}$"),
+]
+EntityNameType = Annotated[
+    str | None,
+    Field(description="The name of the entity."),
+    AfterValidator(_disallowed_characters),
+    AfterValidator(_ensure_url_encodeable),
+]
 
 
 class SOFT5Dimension(BaseModel):
@@ -75,10 +150,8 @@ class SOFT5Property(BaseModel):
 class SOFT5Entity(BaseModel):
     """A SOFT5 Entity returned from this service."""
 
-    name: Annotated[str | None, Field(description="The name of the entity.")] = None
-    version: Annotated[str | None, Field(description="The version of the entity.")] = (
-        None
-    )
+    name: EntityNameType = None
+    version: EntityVersionType = None
     namespace: Annotated[
         AnyHttpUrl | None, Field(description="The namespace of the entity.")
     ] = None
@@ -127,13 +200,26 @@ class SOFT5Entity(BaseModel):
     @field_validator("uri", mode="after")
     @classmethod
     def _validate_uri(cls, value: AnyHttpUrl) -> AnyHttpUrl:
-        """Validate `uri` is consistent with `name`, `version`, and `namespace`."""
-        if URI_REGEX.match(str(value)) is None:
+        """Validate all parts of the `uri`."""
+        try:
+            uri_deconstructed = URI_REGEX.match(str(value))
+        except Exception as error:  # noqa: BLE001
+            error_message = f"The URI is invalid: {error}\n"
+            raise ValueError(error_message) from error
+
+        if uri_deconstructed is None:
             error_message = (
-                "The 'uri' is not a valid SOFT7 entity URI. It must be of the form "
-                f"{str(CONFIG.base_url).rstrip('/')}/{{version}}/{{name}}.\n"
+                "The URI does not match the expected pattern. The URI must be of the "
+                "form `{namespace}/{version}/{name}`.\n"
             )
             raise ValueError(error_message)
+
+        try:
+            TypeAdapter(EntityNameType).validate_python(uri_deconstructed.group("name"))
+        except (ValueError, ValidationError) as error:
+            error_message = f"The name part of the URI is invalid: {error}\n-"
+            raise ValueError(error_message) from error
+
         return value
 
     @field_validator("meta", mode="after")

--- a/entities_service/models/soft5.py
+++ b/entities_service/models/soft5.py
@@ -53,11 +53,8 @@ URI_REGEX = re.compile(
 """Regular expression to parse a SOFT entity URI."""
 
 
-def _disallowed_characters(value: str | None) -> str | None:
+def _disallowed_characters(value: str) -> str:
     """Check that the value does not contain disallowed characters."""
-    if value is None:
-        return value
-
     special_url_characters = ["/", "?", "#", "@", ":"]
     if any(char in value for char in special_url_characters):
         raise ValueError(
@@ -68,11 +65,8 @@ def _disallowed_characters(value: str | None) -> str | None:
     return value
 
 
-def _ensure_url_encodeable(value: str | None) -> str | None:
+def _ensure_url_encodeable(value: str) -> str:
     """Ensure that the value is URL encodeable."""
-    if value is None:
-        return value
-
     try:
         quote(value)
     except Exception as error:  # noqa: BLE001
@@ -81,11 +75,11 @@ def _ensure_url_encodeable(value: str | None) -> str | None:
 
 
 EntityVersionType = Annotated[
-    str | None,
+    str,
     Field(description="The version of the entity.", pattern=rf"^{SEMVER_REGEX}$"),
 ]
 EntityNameType = Annotated[
-    str | None,
+    str,
     Field(description="The name of the entity."),
     AfterValidator(_disallowed_characters),
     AfterValidator(_ensure_url_encodeable),
@@ -150,8 +144,8 @@ class SOFT5Property(BaseModel):
 class SOFT5Entity(BaseModel):
     """A SOFT5 Entity returned from this service."""
 
-    name: EntityNameType = None
-    version: EntityVersionType = None
+    name: EntityNameType | None = None
+    version: EntityVersionType | None = None
     namespace: Annotated[
         AnyHttpUrl | None, Field(description="The namespace of the entity.")
     ] = None

--- a/entities_service/models/soft7.py
+++ b/entities_service/models/soft7.py
@@ -53,11 +53,8 @@ URI_REGEX = re.compile(
 """Regular expression to parse a SOFT entity URI."""
 
 
-def _disallowed_characters(value: str | None) -> str | None:
+def _disallowed_characters(value: str) -> str:
     """Check that the value does not contain disallowed characters."""
-    if value is None:
-        return value
-
     special_url_characters = ["/", "?", "#", "@", ":"]
     if any(char in value for char in special_url_characters):
         raise ValueError(
@@ -68,11 +65,8 @@ def _disallowed_characters(value: str | None) -> str | None:
     return value
 
 
-def _ensure_url_encodeable(value: str | None) -> str | None:
+def _ensure_url_encodeable(value: str) -> str:
     """Ensure that the value is URL encodeable."""
-    if value is None:
-        return value
-
     try:
         quote(value)
     except Exception as error:  # noqa: BLE001
@@ -81,11 +75,11 @@ def _ensure_url_encodeable(value: str | None) -> str | None:
 
 
 EntityVersionType = Annotated[
-    str | None,
+    str,
     Field(description="The version of the entity.", pattern=rf"^{SEMVER_REGEX}$"),
 ]
 EntityNameType = Annotated[
-    str | None,
+    str,
     Field(description="The name of the entity."),
     AfterValidator(_disallowed_characters),
     AfterValidator(_ensure_url_encodeable),
@@ -144,8 +138,8 @@ class SOFT7Property(BaseModel):
 class SOFT7Entity(BaseModel):
     """A SOFT7 Entity returned from this service."""
 
-    name: EntityNameType = None
-    version: EntityVersionType = None
+    name: EntityNameType | None = None
+    version: EntityVersionType | None = None
     namespace: Annotated[
         AnyHttpUrl | None, Field(description="The namespace of the entity.")
     ] = None

--- a/entities_service/models/soft7.py
+++ b/entities_service/models/soft7.py
@@ -5,16 +5,91 @@ from __future__ import annotations
 import difflib
 import re
 from typing import Annotated, Any
+from urllib.parse import quote
 
-from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    Field,
+    TypeAdapter,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
+from pydantic.functional_validators import AfterValidator
 from pydantic.networks import AnyHttpUrl
 
 from entities_service.service.config import CONFIG
 
+SEMVER_REGEX = (
+    r"(?P<major>0|[1-9]\d*)(?:\.(?P<minor>0|[1-9]\d*))?(?:\.(?P<patch>0|[1-9]\d*))?"
+    r"(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    r"(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
+)
+"""Semantic Versioning regular expression.
+
+Slightly changed version of the one found at https://semver.org.
+The changed bits pertain to `minor` and `patch`, which are now both optional.
+"""
+
+NO_GROUPS_SEMVER_REGEX = (
+    r"(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*))?(?:\.(?:0|[1-9]\d*))?"
+    r"(?:-(?:(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    r"(?:\+(?:[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
+)
+"""Semantic Versioning regular expression.
+
+Slightly changed version of the one found at https://semver.org.
+The changed bits pertain to `minor` and `patch`, which are now both optional.
+
+This is the same as `SEMVER_REGEX`, but without the named groups.
+"""
+
 URI_REGEX = re.compile(
-    r"^(?P<namespace>https?://.+)/(?P<version>\d(?:\.\d+){0,2})/(?P<name>[^/#?]+)$"
+    rf"^(?P<namespace>https?://.+)/(?P<version>{NO_GROUPS_SEMVER_REGEX})/(?P<name>[^/#?]+)$"
 )
 """Regular expression to parse a SOFT entity URI."""
+
+
+def _disallowed_characters(value: str | None) -> str | None:
+    """Check that the value does not contain disallowed characters."""
+    if value is None:
+        return value
+
+    special_url_characters = ["/", "?", "#", "@", ":"]
+    if any(char in value for char in special_url_characters):
+        raise ValueError(
+            f"The value must not contain any of {special_url_characters} characters."
+        )
+    if " " in value:
+        raise ValueError("The value must not contain any spaces.")
+    return value
+
+
+def _ensure_url_encodeable(value: str | None) -> str | None:
+    """Ensure that the value is URL encodeable."""
+    if value is None:
+        return value
+
+    try:
+        quote(value)
+    except Exception as error:  # noqa: BLE001
+        raise ValueError(f"The value is not URL encodeable: {error}") from error
+    return value
+
+
+EntityVersionType = Annotated[
+    str | None,
+    Field(description="The version of the entity.", pattern=rf"^{SEMVER_REGEX}$"),
+]
+EntityNameType = Annotated[
+    str | None,
+    Field(description="The name of the entity."),
+    AfterValidator(_disallowed_characters),
+    AfterValidator(_ensure_url_encodeable),
+]
 
 
 class SOFT7Property(BaseModel):
@@ -69,10 +144,8 @@ class SOFT7Property(BaseModel):
 class SOFT7Entity(BaseModel):
     """A SOFT7 Entity returned from this service."""
 
-    name: Annotated[str | None, Field(description="The name of the entity.")] = None
-    version: Annotated[str | None, Field(description="The version of the entity.")] = (
-        None
-    )
+    name: EntityNameType = None
+    version: EntityVersionType = None
     namespace: Annotated[
         AnyHttpUrl | None, Field(description="The namespace of the entity.")
     ] = None
@@ -124,13 +197,26 @@ class SOFT7Entity(BaseModel):
     @field_validator("uri", mode="after")
     @classmethod
     def _validate_uri(cls, value: AnyHttpUrl) -> AnyHttpUrl:
-        """Validate `uri` is consistent with `name`, `version`, and `namespace`."""
-        if URI_REGEX.match(str(value)) is None:
+        """Validate all parts of the `uri`."""
+        try:
+            uri_deconstructed = URI_REGEX.match(str(value))
+        except Exception as error:  # noqa: BLE001
+            error_message = f"The URI is invalid: {error}\n"
+            raise ValueError(error_message) from error
+
+        if uri_deconstructed is None:
             error_message = (
-                "The 'uri' is not a valid SOFT7 entity URI. It must be of the form "
-                f"{str(CONFIG.base_url).rstrip('/')}/{{version}}/{{name}}.\n"
+                "The URI does not match the expected pattern. The URI must be of the "
+                "form `{namespace}/{version}/{name}`.\n"
             )
             raise ValueError(error_message)
+
+        try:
+            TypeAdapter(EntityNameType).validate_python(uri_deconstructed.group("name"))
+        except (ValueError, ValidationError) as error:
+            error_message = f"The name part of the URI is invalid: {error}\n-"
+            raise ValueError(error_message) from error
+
         return value
 
     @field_validator("meta", mode="after")


### PR DESCRIPTION
Fixes #90 

The entity version and name validation is unified to be located mainly in the `models` module, then from there being used in the service - instead of the service having its own special validation implementation.