### PR TITLE
Add ENTITIES_SERVICE_ACCESS_TOKEN env var

### DIFF
--- a/entities_service/cli/_utils/generics.py
+++ b/entities_service/cli/_utils/generics.py
@@ -37,7 +37,6 @@ from rich import print as rich_print
 from rich.console import Console
 
 from entities_service.models.auth import OpenIDConfiguration
-from entities_service.service.config import CONFIG
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, TextIO
@@ -111,6 +110,8 @@ def pretty_compare_dicts(
 
 def initialize_access_token() -> HeaderApiKey | None:
     """Create an API key header."""
+    from entities_service.cli.config import CONFIG
+
     if CONFIG.access_token is None:
         return None
 

--- a/entities_service/cli/_utils/generics.py
+++ b/entities_service/cli/_utils/generics.py
@@ -37,6 +37,7 @@ from rich import print as rich_print
 from rich.console import Console
 
 from entities_service.models.auth import OpenIDConfiguration
+from entities_service.service.config import CONFIG
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, TextIO
@@ -110,8 +111,6 @@ def pretty_compare_dicts(
 
 def initialize_access_token() -> HeaderApiKey | None:
     """Create an API key header."""
-    from entities_service.cli.config import CONFIG
-
     if CONFIG.access_token is None:
         return None
 

--- a/entities_service/cli/_utils/generics.py
+++ b/entities_service/cli/_utils/generics.py
@@ -15,6 +15,7 @@ try:
     from httpx_auth import (
         AuthenticationFailed,
         GrantNotProvided,
+        HeaderApiKey,
         InvalidGrantRequest,
         InvalidToken,
         JsonTokenFileCache,
@@ -36,6 +37,7 @@ from rich import print as rich_print
 from rich.console import Console
 
 from entities_service.models.auth import OpenIDConfiguration
+from entities_service.service.config import CONFIG
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, TextIO
@@ -107,6 +109,17 @@ def pretty_compare_dicts(
     )
 
 
+def initialize_access_token() -> HeaderApiKey | None:
+    """Create an API key header."""
+    if CONFIG.access_token is None:
+        return None
+
+    return HeaderApiKey(
+        api_key=f"Bearer {CONFIG.access_token.get_secret_value()}",
+        header_name="Authorization",
+    )
+
+
 def initialize_oauth2(
     openid_config_url: str | None = None,
 ) -> OAuth2AuthorizationCodePKCE:
@@ -161,5 +174,5 @@ def initialize_oauth2(
     )
 
 
-# OAuth2 authorization code flow
-oauth = initialize_oauth2()
+# Access Token and OAuth2 authorization code flow
+oauth = initialize_access_token() or initialize_oauth2()

--- a/entities_service/models/auth.py
+++ b/entities_service/models/auth.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from enum import Enum, IntEnum
+from enum import IntEnum
 from typing import Annotated
 
 from pydantic import (
@@ -12,12 +12,6 @@ from pydantic import (
 from pydantic.networks import Url, UrlConstraints
 
 AnyHttpsUrl = Annotated[Url, UrlConstraints(allowed_schemes=["https"])]
-
-
-class OAuth2Provider(Enum):
-    """Enumeration of supported OAuth2 providers."""
-
-    GITLAB = "gitlab"
 
 
 class OpenIDConfiguration(BaseModel):

--- a/entities_service/models/auth.py
+++ b/entities_service/models/auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from enum import Enum, IntEnum
 from typing import Annotated
 
 from pydantic import (
@@ -11,6 +12,12 @@ from pydantic import (
 from pydantic.networks import Url, UrlConstraints
 
 AnyHttpsUrl = Annotated[Url, UrlConstraints(allowed_schemes=["https"])]
+
+
+class OAuth2Provider(Enum):
+    """Enumeration of supported OAuth2 providers."""
+
+    GITLAB = "gitlab"
 
 
 class OpenIDConfiguration(BaseModel):
@@ -147,7 +154,7 @@ class OpenIDConfiguration(BaseModel):
     ] = None
 
 
-class GitLabUserInfo(BaseModel):
+class GitLabOpenIDUserInfo(BaseModel):
     """OpenID userinfo response from GitLab.
 
     This is defined in the OpenID Connect specification.
@@ -222,3 +229,46 @@ class GitLabUserInfo(BaseModel):
             ),
         ),
     ] = []
+
+
+class GitLabUser(BaseModel):
+    """GitLab user response.
+
+    This is defined in the GitLab API documentation.
+    Reference: https://docs.gitlab.com/ee/api/users.html#single-user
+    """
+
+    id: Annotated[int, Field(description="User ID.")]
+    name: Annotated[str, Field(description="Name of the user.")]
+    username: Annotated[str, Field(description="Username of the user.")]
+    state: Annotated[str, Field(description="State of the user.")]
+    locked: Annotated[bool, Field(description="Whether the user is locked.")]
+    bot: Annotated[bool, Field(description="Whether the user is a bot.")]
+
+
+class GitLabRole(IntEnum):
+    """Enumeration of GitLab roles."""
+
+    NO_ACCESS = 0
+    MINIMAL_ACCESS = 5
+    GUEST = 10
+    REPORTER = 20
+    DEVELOPER = 30
+    MAINTAINER = 40
+    OWNER = 50
+
+
+class GitLabGroupProjectMember(BaseModel):
+    """GitLab group or project member response.
+
+    This is defined in the GitLab API documentation.
+    Reference: https://docs.gitlab.com/ee/api/members.html#get-a-member-of-a-group-or-project
+    """
+
+    id: Annotated[int, Field(description="Member ID.")]
+    username: Annotated[str, Field(description="Username of the member.")]
+    name: Annotated[str, Field(description="Name of the member.")]
+    state: Annotated[str, Field(description="State of the member.")]
+    access_level: Annotated[
+        GitLabRole, Field(description="Access level of the member.")
+    ]

--- a/entities_service/service/backend/mongodb.py
+++ b/entities_service/service/backend/mongodb.py
@@ -217,7 +217,7 @@ def get_client(
         LOGGER.debug("Using cached MongoDB client for %r.", auth_level)
         return MONGO_CLIENTS[auth_level]
 
-    LOGGER.debug("Creating new MongoDB client for %r.", username)
+    LOGGER.debug("Creating new MongoDB client for %r.", username or "X.509 certificate")
 
     # Ensure all required settings are set
     if auth_level == "read":
@@ -342,7 +342,6 @@ class MongoDBBackend(Backend):
     ) -> list[dict[str, Any]] | dict[str, Any] | None:
         """Create one or more entities in the MongoDB."""
         LOGGER.info("Creating entities: %s", entities)
-        LOGGER.info("The creator's user name: %s", self._settings.mongo_username)
 
         entities = [self._prepare_entity(entity) for entity in entities]
 

--- a/entities_service/service/config.py
+++ b/entities_service/service/config.py
@@ -9,6 +9,7 @@ from pydantic import Field, SecretStr, ValidationInfo, field_validator
 from pydantic.networks import AnyHttpUrl, MultiHostUrl, UrlConstraints
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from entities_service.models.auth import OAuth2Provider
 from entities_service.service.backend import Backends
 
 MongoDsn = Annotated[
@@ -47,8 +48,19 @@ class ServiceSettings(BaseSettings):
 
     # Security
     oauth2_provider: Annotated[
+        OAuth2Provider,
+        Field(
+            description="OAuth2 provider. (Currently only GitLab is supported.)",
+        ),
+    ] = OAuth2Provider.GITLAB
+
+    oauth2_provider_base_url: Annotated[
         AnyHttpUrl, Field(description="OAuth2 provider base URL.")
     ] = AnyHttpUrl("https://gitlab.sintef.no")
+
+    access_token: Annotated[
+        SecretStr | None, Field(description="Access token for the OAuth2 provider.")
+    ] = None
 
     roles_group: Annotated[str, Field(description="GitLab group for roles.")] = (
         "team4.0-authentication/entities-service"

--- a/entities_service/service/config.py
+++ b/entities_service/service/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from enum import Enum
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -9,13 +10,18 @@ from pydantic import Field, SecretStr, ValidationInfo, field_validator
 from pydantic.networks import AnyHttpUrl, MultiHostUrl, UrlConstraints
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from entities_service.models.auth import OAuth2Provider
 from entities_service.service.backend import Backends
 
 MongoDsn = Annotated[
     MultiHostUrl, UrlConstraints(allowed_schemes=["mongodb", "mongodb+srv"])
 ]
 """Support MongoDB schemes with hidden port (no default port)."""
+
+
+class OAuth2Provider(Enum):
+    """Enumeration of supported OAuth2 providers."""
+
+    GITLAB = "gitlab"
 
 
 class ServiceSettings(BaseSettings):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ testing = [
     "dlite-python ~=0.5.1; python_version < '3.12'",
     "mongomock ~=4.1",
     "pytest ~=8.1",
+    "pytest-asyncio ~=0.23.6",
     "pytest-cov ~=5.0",
     "pytest-httpx ~=0.30.0",
     "entities-service[cli]",
@@ -134,6 +135,7 @@ filterwarnings = [
     # starlette's TestClient should be updated
     "ignore:.*'app' shortcut is now deprecated.*:DeprecationWarning",
 ]
+asyncio_mode = "auto"
 
 [tool.coverage.run]
 sigterm = true

--- a/tests/cli/_utils/test_generics.py
+++ b/tests/cli/_utils/test_generics.py
@@ -1,0 +1,31 @@
+"""Test the generic CLI utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.parametrize("access_token", ["test-token", None])
+def test_initialize_access_token(
+    access_token: str | None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test initializing the access token."""
+    from httpx_auth import HeaderApiKey
+    from pydantic import SecretStr
+
+    from entities_service.service.config import ServiceSettings
+
+    if access_token is not None:
+        monkeypatch.setattr(
+            "entities_service.cli._utils.generics.CONFIG",
+            ServiceSettings(access_token=SecretStr(access_token)),
+        )
+
+    from entities_service.cli._utils.generics import initialize_access_token
+
+    oauth = initialize_access_token()
+    if access_token is None:
+        assert oauth is None
+    else:
+        assert isinstance(oauth, HeaderApiKey)
+        assert oauth.api_key == f"Bearer {access_token}"

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -155,7 +155,7 @@ def _mock_successful_oauth_response(
 
     # Mock response for "Get token"
     httpx_mock.add_response(
-        url=f"{str(CONFIG.oauth2_provider).rstrip('/')}/oauth/token",
+        url=f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}/oauth/token",
         method="POST",
         json={"access_token": token_mock},
     )
@@ -183,7 +183,7 @@ def _mock_failed_oauth_response(
 
     # Mock response for "Get token"
     httpx_mock.add_response(
-        url=f"{str(CONFIG.oauth2_provider).rstrip('/')}/oauth/token",
+        url=f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}/oauth/token",
         method="POST",
         status_code=401,
         headers={"WWW-Authenticate": "Bearer"},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -676,20 +676,22 @@ def mock_auth_verification(
     # OpenID configuration
     httpx_mock.add_response(
         url=(
-            f"{str(CONFIG.oauth2_provider).rstrip('/')}"
+            f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}"
             "/.well-known/openid-configuration"
         ),
         json={
-            "issuer": str(CONFIG.oauth2_provider).rstrip("/"),
+            "issuer": str(CONFIG.oauth2_provider_base_url).rstrip("/"),
             "authorization_endpoint": (
-                f"{str(CONFIG.oauth2_provider).rstrip('/')}/oauth/authorize"
+                f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}/oauth/authorize"
             ),
-            "token_endpoint": f"{str(CONFIG.oauth2_provider).rstrip('/')}/oauth/token",
+            "token_endpoint": (
+                f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}/oauth/token"
+            ),
             "userinfo_endpoint": (
-                f"{str(CONFIG.oauth2_provider).rstrip('/')}/oauth/userinfo"
+                f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}/oauth/userinfo"
             ),
             "jwks_uri": (
-                f"{str(CONFIG.oauth2_provider).rstrip('/')}/oauth/discovery/keys"
+                f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}/oauth/discovery/keys"
             ),
             "response_types_supported": [
                 "code",
@@ -728,22 +730,22 @@ def mock_auth_verification(
 
         # Userinfo endpoint
         httpx_mock.add_response(
-            url=f"{str(CONFIG.oauth2_provider).rstrip('/')}/oauth/userinfo",
+            url=f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}/oauth/userinfo",
             json={
                 "sub": backend_user["username"],
                 "name": backend_user["username"],
                 "nickname": backend_user["username"],
                 "preferred_username": backend_user["username"],
                 "website": (
-                    f"{str(CONFIG.oauth2_provider).rstrip('/')}"
+                    f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}"
                     f"/{backend_user['username']}"
                 ),
                 "profile": (
-                    f"{str(CONFIG.oauth2_provider).rstrip('/')}"
+                    f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}"
                     f"/{backend_user['username']}"
                 ),
                 "picture": (
-                    f"{str(CONFIG.oauth2_provider).rstrip('/')}"
+                    f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}"
                     f"/{backend_user['username']}"
                 ),
                 "groups": [CONFIG.roles_group],

--- a/tests/service/test_security.py
+++ b/tests/service/test_security.py
@@ -1,0 +1,513 @@
+"""Test the entities_service.service.security module."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from typing import Any, Literal
+
+    from pytest_httpx import HTTPXMock
+
+    from ..conftest import MockOpenIDConfigCall
+
+
+@pytest.fixture()
+def user_info() -> dict[str, Any]:
+    """Test data for verify_user_access_token() function."""
+    return {
+        "id": 1,
+        "username": "john_smith",
+        "name": "John Smith",
+        "state": "active",
+        "locked": False,
+        "avatar_url": "http://localhost:3000/uploads/user/avatar/1/cd8.jpeg",
+        "web_url": "http://localhost:3000/john_smith",
+        "created_at": "2012-05-23T08:00:58Z",
+        "bio": "",
+        "bot": False,
+        "location": None,
+        "public_email": "john@example.com",
+        "skype": "",
+        "linkedin": "",
+        "twitter": "",
+        "discord": "",
+        "website_url": "",
+        "organization": "",
+        "job_title": "Operations Specialist",
+        "pronouns": "he/him",
+        "work_information": None,
+        "followers": 1,
+        "following": 1,
+        "local_time": "3:38 PM",
+        "is_followed": False,
+    }
+
+
+@pytest.fixture()
+def group_member_info() -> dict[str, Any]:
+    """Test data for verify_user_access_token() function."""
+    return {
+        "id": 1,
+        "username": "john_smith",
+        "name": "John Smith",
+        "state": "active",
+        "avatar_url": "http://localhost:3000/uploads/user/avatar/1/cd8.jpeg",
+        "web_url": "http://localhost:3000/john_smith",
+        "access_level": 30,  # Developer
+        "email": "john@example.com",
+        "created_at": "2012-10-22T14:13:35Z",
+        "created_by": {
+            "id": 2,
+            "username": "john_doe",
+            "name": "John Doe",
+            "state": "active",
+            "avatar_url": "https://www.gravatar.com/avatar/c2525a7f58ae3776070e44c106c48e15?s=80&d=identicon",
+            "web_url": "http://192.168.1.8:3000/root",
+        },
+        "expires_at": None,
+        "group_saml_identity": None,
+    }
+
+
+async def test_get_openid_config(mock_openid_config_call: MockOpenIDConfigCall) -> None:
+    """Test get_openid_config() function."""
+    from entities_service.models.auth import OpenIDConfiguration
+    from entities_service.service.config import CONFIG
+    from entities_service.service.security import get_openid_config
+
+    # Mock successful OpenID configuration response
+    mock_openid_config_call(str(CONFIG.oauth2_provider_base_url).rstrip("/"))
+
+    assert isinstance(await get_openid_config(), OpenIDConfiguration)
+
+
+async def test_openid_source_down(httpx_mock: HTTPXMock) -> None:
+    """Test get_openid_config() function raises ValueError when the OpenID source is
+    down.
+
+    The HTTPX standard protocol is to raise a TimeoutException when the server is
+    unreachable.
+    """
+    from httpx import TimeoutException
+
+    from entities_service.service.security import get_openid_config
+
+    # Mock HTTP Timeout
+    httpx_mock.add_exception(TimeoutException("Connection timeout."))
+
+    with pytest.raises(ValueError, match="Could not get OpenID configuration."):
+        await get_openid_config()
+
+
+async def test_openid_config_parse_error(httpx_mock: HTTPXMock) -> None:
+    """Test get_openid_config() function raises ValueError when the OpenID
+    configuration cannot be parsed."""
+    from pydantic import ValidationError
+
+    from entities_service.models.auth import OpenIDConfiguration
+    from entities_service.service.security import get_openid_config
+
+    invalid_openid_response = {"invalid": "response"}
+
+    # Ensure invalid OpenID configuration response is invalid
+    with pytest.raises(ValidationError):
+        OpenIDConfiguration(**invalid_openid_response)
+
+    # Mock invalid OpenID configuration response
+    httpx_mock.add_response(json=invalid_openid_response)
+
+    with pytest.raises(ValueError, match="Could not parse OpenID configuration."):
+        await get_openid_config()
+
+
+async def test_verify_user_access_token(
+    httpx_mock: HTTPXMock,
+    user_info: dict[str, Any],
+    group_member_info: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test verify_user_access_token() function.
+
+    "Test data" is lifted from the GitLab documentation.
+    """
+    from urllib.parse import quote_plus
+
+    from entities_service.models.auth import (
+        GitLabGroupProjectMember,
+        GitLabRole,
+        GitLabUser,
+    )
+    from entities_service.service.config import CONFIG
+    from entities_service.service.security import verify_user_access_token
+
+    mock_token = "mock_token"
+
+    # Validate test data will result in successful "passage" through the function
+    parsed_user = GitLabUser(**user_info)
+    assert parsed_user.state == "active"
+    assert parsed_user.locked is False
+
+    parsed_member = GitLabGroupProjectMember(**group_member_info)
+    for attr in ("id", "username", "name", "state"):
+        assert getattr(parsed_member, attr) == getattr(parsed_user, attr)
+    assert parsed_member.access_level >= GitLabRole.DEVELOPER  # Minimum access level
+
+    # Mock successful responses
+    httpx_mock.add_response(
+        url=f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}/api/v4/user",
+        json=user_info,
+        headers={"Authorization": f"Bearer {mock_token}"},
+    )
+    httpx_mock.add_response(
+        url=(
+            f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}/api/v4/groups/"
+            f"{quote_plus(CONFIG.roles_group)}/members/{user_info['id']}"
+        ),
+        json=group_member_info,
+        headers={"Authorization": f"Bearer {mock_token}"},
+    )
+
+    with caplog.at_level("DEBUG", logger="entities_service"):
+        assert await verify_user_access_token(mock_token) == (True, None, None)
+
+    assert (
+        f"User {parsed_member.name} ({parsed_member.id}, {parsed_member.username}) has "
+        "the rights to create entities."
+    ) in caplog.messages
+    assert f"User: {parsed_user.name}" in caplog.messages
+
+
+@pytest.mark.parametrize("user_state", ["blocked", "locked"])
+async def test_verify_user_access_token_inactive_user(
+    httpx_mock: HTTPXMock,
+    user_info: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+    user_state: Literal["blocked", "locked"],
+) -> None:
+    """Test verify_user_access_token() function returns False with a blocked or locked
+    (inactive) user."""
+    from entities_service.models.auth import GitLabUser
+    from entities_service.service.config import CONFIG
+    from entities_service.service.security import verify_user_access_token
+
+    mock_token = "mock_token"
+
+    # Set user state to blocked or locked
+    if user_state == "blocked":
+        user_info["state"] = "blocked"
+    else:
+        user_info["state"] = "active"
+        user_info["locked"] = True
+
+    # Validate test data is still valid according to the model
+    assert GitLabUser(**user_info)
+
+    # Mock successful response
+    httpx_mock.add_response(
+        url=f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}/api/v4/user",
+        json=user_info,
+        headers={"Authorization": f"Bearer {mock_token}"},
+    )
+
+    with caplog.at_level("DEBUG", logger="entities_service"):
+        assert await verify_user_access_token(mock_token) == (
+            False,
+            403,
+            "Your user account is not active or is locked. "
+            "Please contact your GitLab administrator(s).",
+        )
+
+    assert (
+        f"User is not active or is locked. (Username: {user_info['username']})"
+        in caplog.messages
+    )
+
+
+@pytest.mark.parametrize(
+    ("differing_attr", "differing_value"),
+    [
+        ("id", 2),
+        ("username", "raymond_smith"),
+        ("name", "Raymond Smith"),
+        ("state", "blocked"),
+    ],
+)
+async def test_verify_user_access_token_different_member(
+    httpx_mock: HTTPXMock,
+    user_info: dict[str, Any],
+    group_member_info: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+    differing_attr: Literal["id", "username", "name", "state"],
+    differing_value: Literal[2, "raymond_smith", "Raymond Smith", "blocked"],
+) -> None:
+    """Test verify_user_access_token() function returns False if a returned group member
+    differs from the current user."""
+    from urllib.parse import quote_plus
+
+    from entities_service.models.auth import GitLabGroupProjectMember, GitLabUser
+    from entities_service.service.config import CONFIG
+    from entities_service.service.security import verify_user_access_token
+
+    mock_token = "mock_token"
+
+    # Validate test data is still valid according to the model
+    assert GitLabUser(**user_info)
+
+    # Set group member info to differ from user info
+    group_member_info[differing_attr] = differing_value
+    assert group_member_info[differing_attr] != user_info[differing_attr]
+    assert GitLabGroupProjectMember(**group_member_info)
+
+    # Mock successful responses
+    httpx_mock.add_response(
+        url=f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}/api/v4/user",
+        json=user_info,
+        headers={"Authorization": f"Bearer {mock_token}"},
+    )
+    httpx_mock.add_response(
+        url=(
+            f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}/api/v4/groups/"
+            f"{quote_plus(CONFIG.roles_group)}/members/{user_info['id']}"
+        ),
+        json=group_member_info,
+        headers={"Authorization": f"Bearer {mock_token}"},
+    )
+
+    with caplog.at_level("DEBUG", logger="entities_service"):
+        assert await verify_user_access_token(mock_token) == (False, None, None)
+
+    assert "Member info does not match the user info." in caplog.messages
+
+
+async def test_verify_user_access_token_bad_access_level(
+    httpx_mock: HTTPXMock,
+    user_info: dict[str, Any],
+    group_member_info: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test verify_user_access_token() function returns False if a user has an access
+    level below the minimum required (DEVELOPER)."""
+    from urllib.parse import quote_plus
+
+    from entities_service.models.auth import (
+        GitLabGroupProjectMember,
+        GitLabRole,
+        GitLabUser,
+    )
+    from entities_service.service.config import CONFIG
+    from entities_service.service.security import (
+        MINIMUM_GROUP_ACCESS_LEVEL,
+        verify_user_access_token,
+    )
+
+    mock_token = "mock_token"
+
+    # Validate test data is still valid according to the model
+    assert GitLabUser(**user_info)
+
+    # Set group member access level to below the minimum required
+    assert GitLabRole.NO_ACCESS < MINIMUM_GROUP_ACCESS_LEVEL
+    group_member_info["access_level"] = GitLabRole.NO_ACCESS
+    parsed_member = GitLabGroupProjectMember(**group_member_info)
+
+    # Mock successful responses
+    httpx_mock.add_response(
+        url=f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}/api/v4/user",
+        json=user_info,
+        headers={"Authorization": f"Bearer {mock_token}"},
+    )
+    httpx_mock.add_response(
+        url=(
+            f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}/api/v4/groups/"
+            f"{quote_plus(CONFIG.roles_group)}/members/{user_info['id']}"
+        ),
+        json=group_member_info,
+        headers={"Authorization": f"Bearer {mock_token}"},
+    )
+
+    with caplog.at_level("DEBUG", logger="entities_service"):
+        assert await verify_user_access_token(mock_token) == (
+            False,
+            403,
+            (
+                "You do not have the rights to create entities. "
+                "Please contact the entities-service group maintainer."
+            ),
+        )
+
+    assert (
+        "User does not have the rights to create entities. Hint: Change "
+        f"{parsed_member.username}'s role in the GitLab group {CONFIG.roles_group!r}"
+    ) in caplog.messages
+
+
+async def test_verify_user_access_token_source_down(
+    httpx_mock: HTTPXMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test verify_user_access_token() function returns False when the OAuth2 source is
+    down."""
+    from httpx import TimeoutException
+
+    from entities_service.service.security import verify_user_access_token
+
+    # Mock HTTP Timeout
+    httpx_mock.add_exception(TimeoutException("Connection timeout."))
+
+    with caplog.at_level("DEBUG", logger="entities_service"):
+        assert await verify_user_access_token("mock_token") == (False, None, None)
+
+    assert "Connection timeout." in caplog.text
+    assert "Could not get user info from GitLab provider." in caplog.messages
+
+
+async def test_verify_user_access_token_source_down_midway(
+    httpx_mock: HTTPXMock, user_info: dict[str, Any], caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test verify_user_access_token() function returns False when the OAuth2 source
+    goes down in between calls."""
+    from urllib.parse import quote_plus
+
+    from httpx import TimeoutException
+
+    from entities_service.models.auth import GitLabUser
+    from entities_service.service.config import CONFIG
+    from entities_service.service.security import verify_user_access_token
+
+    mock_token = "mock_token"
+
+    # Validate test data is still valid according to the model
+    assert GitLabUser(**user_info)
+
+    # Mock successful initial response
+    httpx_mock.add_response(
+        url=f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}/api/v4/user",
+        json=user_info,
+        headers={"Authorization": f"Bearer {mock_token}"},
+    )
+
+    # Mock HTTP Timeout
+    httpx_mock.add_exception(
+        TimeoutException("Connection timeout."),
+        url=(
+            f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}/api/v4/groups/"
+            f"{quote_plus(CONFIG.roles_group)}/members/{user_info['id']}"
+        ),
+    )
+
+    with caplog.at_level("DEBUG", logger="entities_service"):
+        assert await verify_user_access_token("mock_token") == (
+            False,
+            403,
+            (
+                "You are not a member of the entities-service group. "
+                "Please contact the entities-service group maintainer."
+            ),
+        )
+
+    assert "Connection timeout." in caplog.text
+    assert "User is not a member of the entities-service group." in caplog.messages
+
+
+async def test_verify_user_access_token_user_is_not_member(
+    httpx_mock: HTTPXMock,
+    user_info: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test verify_user_access_token() function returns False when a user is not a
+    member of the entities-service group."""
+    from urllib.parse import quote_plus
+
+    from entities_service.models.auth import GitLabUser
+    from entities_service.service.config import CONFIG
+    from entities_service.service.security import verify_user_access_token
+
+    mock_token = "mock_token"
+
+    # Validate test data is still valid according to the model
+    assert GitLabUser(**user_info)
+
+    # Mock successful responses
+    httpx_mock.add_response(
+        url=f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}/api/v4/user",
+        json=user_info,
+        headers={"Authorization": f"Bearer {mock_token}"},
+    )
+    httpx_mock.add_response(
+        url=(
+            f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}/api/v4/groups/"
+            f"{quote_plus(CONFIG.roles_group)}/members/{user_info['id']}"
+        ),
+        json={"error": "404 Not Found"},
+        status_code=404,
+    )
+
+    with caplog.at_level("DEBUG", logger="entities_service"):
+        assert await verify_user_access_token(mock_token) == (
+            False,
+            403,
+            (
+                "You are not a member of the entities-service group. "
+                "Please contact the entities-service group maintainer."
+            ),
+        )
+
+    assert "Connection timeout." not in caplog.text
+    assert "User is not a member of the entities-service group." in caplog.messages
+
+
+async def test_verify_user_access_token_parse_error_user(
+    httpx_mock: HTTPXMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test verify_user_access_token() function returns False when the user info cannot
+    be parsed."""
+    import json
+
+    from entities_service.service.security import verify_user_access_token
+
+    # Mock invalid user info response
+    httpx_mock.add_response(json={"invalid": "response"})
+
+    with caplog.at_level("DEBUG", logger="entities_service"):
+        assert await verify_user_access_token("mock_token") == (False, None, None)
+
+    assert "Could not parse user info from GitLab provider." in caplog.messages
+    assert f"Response:\n{json.dumps({'invalid': 'response'})}" in caplog.messages
+
+
+async def test_verify_user_access_token_parse_error_member(
+    httpx_mock: HTTPXMock,
+    user_info: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test verify_user_access_token() function returns False when the group member info
+    cannot be parsed."""
+    import json
+
+    from entities_service.models.auth import GitLabUser
+    from entities_service.service.config import CONFIG
+    from entities_service.service.security import verify_user_access_token
+
+    mock_token = "mock_token"
+
+    # Validate test data is still valid according to the model
+    assert GitLabUser(**user_info)
+
+    # Mock successful initial response
+    httpx_mock.add_response(
+        url=f"{str(CONFIG.oauth2_provider_base_url).rstrip('/')}/api/v4/user",
+        json=user_info,
+        headers={"Authorization": f"Bearer {mock_token}"},
+    )
+
+    # Mock invalid group member info response
+    httpx_mock.add_response(json={"invalid": "response"})
+
+    with caplog.at_level("DEBUG", logger="entities_service"):
+        assert await verify_user_access_token(mock_token) == (False, None, None)
+
+    assert "Could not parse user info from GitLab provider." not in caplog.messages
+    assert "Could not parse member role from GitLab provider." in caplog.messages
+    assert f"Response:\n{json.dumps({'invalid': 'response'})}" in caplog.messages


### PR DESCRIPTION
Closes #108 

This can be set to avoid doing OAuth2 authentication for the CLI, for example when using the CLI in connection with CI/CD.