### PR TITLE
List entities in namespace(s)

### DIFF
--- a/entities_service/cli/main.py
+++ b/entities_service/cli/main.py
@@ -28,8 +28,10 @@ except ImportError as exc:  # pragma: no cover
 
     raise ImportError(EXC_MSG_INSTALL_PACKAGE) from exc
 
+import contextlib
+
 import yaml
-from pydantic import AnyHttpUrl
+from pydantic import AnyHttpUrl, ValidationError
 
 from entities_service.cli._utils.generics import (
     ERROR_CONSOLE,
@@ -584,3 +586,100 @@ def login(
 
     if not quiet:
         print("[bold green]Successfully logged in.[/bold green]")
+
+
+@APP.command(name="list")
+def list_entities(
+    namespace: OptionalStr = typer.Option(
+        str(CONFIG.base_url).rstrip("/"),
+        "--namespace",
+        "-n",
+        help="Namespace to list entities from.",
+        show_default=True,
+    )
+) -> None:
+    """List entities from the entities service."""
+    if namespace is None:
+        namespace = str(CONFIG.base_url).rstrip("/")
+
+    namespace_as_url: AnyHttpUrl | None = None
+    with contextlib.suppress(ValidationError):
+        namespace_as_url = AnyHttpUrl(namespace)
+
+    if namespace_as_url is not None:
+        # Validate namespace and retrieve the specific namespace (if any)
+        if (match := URI_REGEX.match(str(namespace_as_url))) is None:
+            ERROR_CONSOLE.print(
+                f"[bold red]Error[/bold red]: Namespace {namespace_as_url} does not "
+                "match the URI regex."
+            )
+            raise typer.Exit(1)
+
+        # Replace the namespace with the specific namespace
+        # This will be `None` if the namespace is the "core" namespace
+        namespace = match.group("specific_namespace")
+
+    # Namespace is now the specific namespace (str) or the "core" namespace (None)
+    path_prefix = f"/{namespace}" if namespace is not None else ""
+
+    with httpx.Client(base_url=str(CONFIG.base_url)) as client:
+        try:
+            response = client.get(
+                f"{path_prefix}/_api/entities",
+                params={"namespace": namespace},
+            )
+        except httpx.HTTPError as exc:
+            ERROR_CONSOLE.print(
+                f"[bold red]Error[/bold red]: Could not list entities. HTTP exception: "
+                f"{exc}"
+            )
+            raise typer.Exit(1) from exc
+
+    if not response.is_success:
+        try:
+            error_message = response.json()
+        except json.JSONDecodeError as exc:
+            ERROR_CONSOLE.print(
+                f"[bold red]Error[/bold red]: Could not list entities. JSON decode "
+                f"error: {exc}"
+            )
+            raise typer.Exit(1) from exc
+
+        ERROR_CONSOLE.print(
+            f"[bold red]Error[/bold red]: Could not list entities. HTTP status code: "
+            f"{response.status_code}. Error response: "
+        )
+        ERROR_CONSOLE.print_json(data=error_message)
+        raise typer.Exit(1)
+
+    # We do not need to validate the response, since the server's response model will do
+    # that for us
+    entities: list[Entity] = [soft_entity(**entity) for entity in response.json()]
+
+    if not entities:
+        print(f"No entities found in namespace {namespace}")
+        raise typer.Exit()
+
+    # Print entities
+    table = Table(
+        title=f"Entities in namespace {namespace}:",
+        title_style="bold",
+        title_justify="left",
+        box=box.SIMPLE_HEAD,
+        highlight=True,
+    )
+
+    table.add_column("Name", no_wrap=True)
+    table.add_column("Version", no_wrap=True)
+
+    previous_entity_name = ""
+    for entity in sorted(entities, key=lambda entity: entity.name):
+        if entity.name == previous_entity_name:
+            # Only add the version
+            table.add_row("", entity.version)
+        else:
+            table.add_row(entity.name, entity.version)
+
+        previous_entity_name = entity.name
+
+    print("", table)

--- a/entities_service/service/backend/backend.py
+++ b/entities_service/service/backend/backend.py
@@ -149,7 +149,7 @@ class Backend(ABC):
 
     # Backend methods (search)
     @abstractmethod
-    def search(self, query: Any) -> Iterator[dict[str, Any]]:  # pragma: no cover
+    def search(self, query: Any = None) -> Iterator[dict[str, Any]]:  # pragma: no cover
         """Search for entities."""
         raise NotImplementedError
 

--- a/entities_service/service/backend/mongodb.py
+++ b/entities_service/service/backend/mongodb.py
@@ -377,7 +377,7 @@ class MongoDBBackend(Backend):
         filter = self._single_uri_query(str(entity_identity))
         self._collection.delete_one(filter)
 
-    def search(self, query: Any) -> Iterator[dict[str, Any]]:
+    def search(self, query: Any = None) -> Iterator[dict[str, Any]]:
         """Search for entities."""
         query = query or {}
 

--- a/entities_service/service/routers/admin.py
+++ b/entities_service/service/routers/admin.py
@@ -1,10 +1,8 @@
 """The `_admin` router and endpoints.
 
-This router is used for both more introspective service endpoints, such as inspecting
-the current and all users, and for endpoints requiring administrative rights, such as
-creating entities.
+This router is used for creating entities.
 
-The endpoints in this router are not documented in the OpenAPI schema.
+Endpoints in this router are not documented in the OpenAPI schema.
 """
 
 from __future__ import annotations
@@ -29,6 +27,7 @@ LOGGER = logging.getLogger(__name__)
 
 ROUTER = APIRouter(
     prefix="/_admin",
+    tags=["Admin"],
     include_in_schema=CONFIG.debug,
     dependencies=[Depends(verify_token)],
 )

--- a/entities_service/service/routers/api.py
+++ b/entities_service/service/routers/api.py
@@ -1,0 +1,83 @@
+"""The `_api` router and endpoints.
+
+This router is used for more introspective service endpoints.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated, Any
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import AnyHttpUrl
+
+from entities_service.models import URI_REGEX, Entity
+from entities_service.service.backend import get_backend
+from entities_service.service.config import CONFIG
+
+LOGGER = logging.getLogger(__name__)
+
+ROUTER = APIRouter(prefix="/_api", tags=["API"])
+
+
+@ROUTER.get(
+    "/entities",
+    response_model=list[Entity],
+    response_model_by_alias=True,
+    response_model_exclude_unset=True,
+)
+async def list_entities(
+    namespaces: Annotated[
+        list[AnyHttpUrl | str] | None,
+        Query(
+            alias="namespace",
+            description=(
+                "A namespace wherein to list all entities. Can be supplied multiple "
+                "times - entities will be returned as an aggregated, flat list."
+            ),
+        ),
+    ] = None
+) -> list[dict[str, Any]]:
+    """List all entities in the given namespace(s)."""
+    # Format namespaces
+    parsed_namespaces: set[str | None] = set()
+    bad_namespaces: list[AnyHttpUrl | str] = []
+
+    for namespace in namespaces or []:
+        if isinstance(namespace, AnyHttpUrl):
+            # Validate namespace and retrieve the specific namespace (if any)
+            if (match := URI_REGEX.match(str(namespace))) is None:
+                LOGGER.error("Namespace %r does not match the URI regex.", namespace)
+                bad_namespaces.append(namespace)
+                continue
+
+            # Replace the namespace with the specific namespace
+            # This will be `None` if the namespace is the "core" namespace
+            parsed_namespaces.add(match.group("specific_namespace"))
+
+    if bad_namespaces:
+        # Raise an error if there are any bad namespaces
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Invalid namespace{'s' if len(bad_namespaces) > 1 else ''}: "
+                f"{', '.join(map(str, bad_namespaces))}."
+            ),
+        )
+
+    if not parsed_namespaces:
+        return []
+
+    # Retrieve entities
+    entities = []
+    for namespace in parsed_namespaces:
+        # Retrieve entities from the database
+        entities.extend(await retrieve_entities(namespace))
+
+    return entities
+
+
+async def retrieve_entities(namespace: str | None) -> list[dict[str, Any]]:
+    """Retrieve entities from the namespace-specific backend."""
+    backend = get_backend(CONFIG.backend, auth_level="read", db=namespace)
+    return list(backend.search())


### PR DESCRIPTION
Closes #107 

Add a new `list` CLI command that will list all Entities in a given `--namespace`.
If `--namespace/-n` is not given, the "core" namespace will be used by default.

A new `/_api` router has been added to the service, for now only including the `GET /entities` endpoint, which accepts multiple `namespace` query parameters, and will collect and return all entities in the given namespace(s).