### PR TITLE
Fix using access token

### DIFF
--- a/entities_service/service/security.py
+++ b/entities_service/service/security.py
@@ -206,15 +206,8 @@ async def verify_token(
 
     if error or not response.is_success:
         LOGGER.error("Could not get user info from OAuth2 provider.")
-        raise credentials_exception
 
-    try:
-        userinfo = GitLabOpenIDUserInfo(**response.json())
-    except (JSONDecodeError, ValidationError) as exc:
-        LOGGER.error("Could not parse user info from OAuth2 provider.")
-        LOGGER.error("Response:\n%s", response.text)
-
-        # If this fails, it may be that we are dealing with a user-provided access token
+        # Since this failed, we may be dealing with a user-provided access token
         verified, status_code, error_msg = await verify_user_access_token(
             credentials.credentials
         )
@@ -228,6 +221,13 @@ async def verify_token(
         if error_msg is not None:
             credentials_exception.detail = error_msg
 
+        raise credentials_exception
+
+    try:
+        userinfo = GitLabOpenIDUserInfo(**response.json())
+    except (JSONDecodeError, ValidationError) as exc:
+        LOGGER.error("Could not parse user info from OAuth2 provider.")
+        LOGGER.error("Response:\n%s", response.text)
         LOGGER.exception(exc)
         raise credentials_exception from exc
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,11 @@ if TYPE_CHECKING:
             self, auth_role: Literal["read", "write"] | None = None
         ) -> None: ...
 
+    class OpenIDConfigMock(Protocol):
+        """Protocol for the openid_config_mock fixture."""
+
+        def __call__(self, base_url: str) -> dict[str, Any]: ...
+
     class MockOpenIDConfigCall(Protocol):
         """Protocol for the mock_openid_config_call fixture."""
 
@@ -670,24 +675,37 @@ def auth_header(token_mock: str) -> dict[Literal["Authorization"], str]:
 
 
 @pytest.fixture()
-def mock_openid_config_call(httpx_mock: HTTPXMock) -> MockOpenIDConfigCall:
+def openid_config_mock() -> OpenIDConfigMock:
+    """Return a mock OpenID configuration."""
+
+    def _openid_config_mock(base_url: str) -> dict[str, Any]:
+        """Return a mock OpenID configuration for `base_url`."""
+        return {
+            "issuer": base_url,
+            "authorization_endpoint": f"{base_url}/oauth/authorize",
+            "token_endpoint": f"{base_url}/oauth/token",
+            "userinfo_endpoint": f"{base_url}/oauth/userinfo",
+            "jwks_uri": f"{base_url}/oauth/discovery/keys",
+            "response_types_supported": ["code"],
+            "subject_types_supported": ["public"],
+            "id_token_signing_alg_values_supported": ["RS256"],
+            "code_challenge_methods_supported": ["plain", "S256"],
+        }
+
+    return _openid_config_mock
+
+
+@pytest.fixture()
+def mock_openid_config_call(
+    httpx_mock: HTTPXMock, openid_config_mock: OpenIDConfigMock
+) -> MockOpenIDConfigCall:
     """Mock the OpenID configuration."""
 
     def _mock_openid_config_call(base_url: str) -> None:
         """Mock the OpenID configuration at `base_url`."""
         httpx_mock.add_response(
             url=f"{base_url}/.well-known/openid-configuration",
-            json={
-                "issuer": base_url,
-                "authorization_endpoint": f"{base_url}/oauth/authorize",
-                "token_endpoint": f"{base_url}/oauth/token",
-                "userinfo_endpoint": f"{base_url}/oauth/userinfo",
-                "jwks_uri": f"{base_url}/oauth/discovery/keys",
-                "response_types_supported": ["code"],
-                "subject_types_supported": ["public"],
-                "id_token_signing_alg_values_supported": ["RS256"],
-                "code_challenge_methods_supported": ["plain", "S256"],
-            },
+            json=openid_config_mock(base_url=base_url),
         )
 
     return _mock_openid_config_call


### PR DESCRIPTION
Fixes #112 

This moves the call to `verify_user_access_token()` "up" in the `verify_token()` function as well as tests that the function is invoked when expected.