### PR TITLE
New `--auto-confirm/-y` option for `upload` cmd

### DIFF
--- a/entities_service/cli/commands/upload.py
+++ b/entities_service/cli/commands/upload.py
@@ -175,21 +175,21 @@ def upload(
                     f"\n\n{valid_entity.pretty_diff}\n"
                 )
 
-                if not auto_confirm:
-                    try:
-                        update_version = typer.confirm(
-                            "You cannot overwrite external existing entities. Do you "
-                            "wish to upload the new entity with an updated version "
-                            "number?",
-                            default=True,
-                        )
-                    except typer.Abort:  # pragma: no cover
-                        # Can only happen if the user presses Ctrl-C, which can not be
-                        # tested currently
-                        update_version = False
-            elif quiet or auto_confirm:
+            if quiet or auto_confirm:
                 # Use default / auto confirm
                 update_version = True
+            else:
+                try:
+                    update_version = typer.confirm(
+                        "You cannot overwrite external existing entities. Do you "
+                        "wish to upload the new entity with an updated version "
+                        "number?",
+                        default=True,
+                    )
+                except typer.Abort:  # pragma: no cover
+                    # Can only happen if the user presses Ctrl-C, which can not be
+                    # tested currently
+                    update_version = False
 
             if not update_version:
                 if not quiet:
@@ -199,12 +199,21 @@ def upload(
                     )
                 continue
 
-            if not quiet or not auto_confirm:
+            if quiet or auto_confirm:
+                # Use default / auto confirm
+                new_version = get_updated_version(valid_entity.entity)
+
+                if not quiet:
+                    print(
+                        "[bold blue]Info[/bold blue]: Updating the to-be-uploaded "
+                        f"entity to version: {new_version}."
+                    )
+            else:
                 # Passing incoming entity-as-model here, since the URIs (and thereby the
                 # versions) have already been determined to be the same, and the
                 # function only accepts models.
                 try:
-                    new_version: str = typer.prompt(
+                    new_version = typer.prompt(
                         "The external existing entity's version is "
                         f"{get_version(valid_entity.entity)!r}. Please enter the new "
                         "version",
@@ -220,15 +229,6 @@ def upload(
                             f"{get_uri(valid_entity.entity)}\n"
                         )
                     continue
-            else:
-                # Use default / auto confirm
-                new_version = get_updated_version(valid_entity.entity)
-
-                if not quiet:
-                    print(
-                        "[bold blue]Info[/bold blue]: Updating the to-be-uploaded "
-                        f"entity to version: {new_version}."
-                    )
 
             # Validate new version
             error_message = ""

--- a/entities_service/cli/commands/upload.py
+++ b/entities_service/cli/commands/upload.py
@@ -206,7 +206,7 @@ def upload(
                 if not quiet:
                     print(
                         "[bold blue]Info[/bold blue]: Updating the to-be-uploaded "
-                        f"entity to version: {new_version}."
+                        f"entity to specified version: {new_version}."
                     )
             else:
                 # Passing incoming entity-as-model here, since the URIs (and thereby the

--- a/tests/cli/commands/test_upload.py
+++ b/tests/cli/commands/test_upload.py
@@ -477,7 +477,8 @@ def test_existing_entity_different_content(
     ), CLI_RESULT_FAIL_MESSAGE.format(stdout=result.stdout, stderr=result.stderr)
     # Ensure specific `quiet=False` and `auto_confirm=True` outputs are in the output
     assert (
-        "Info: Updating the to-be-uploaded entity to version:" in result.stdout
+        "Info: Updating the to-be-uploaded entity to specified version:"
+        in result.stdout
     ), CLI_RESULT_FAIL_MESSAGE.format(stdout=result.stdout, stderr=result.stderr)
     assert "Entities to upload" in result.stdout, CLI_RESULT_FAIL_MESSAGE.format(
         stdout=result.stdout, stderr=result.stderr

--- a/tests/cli/commands/test_upload.py
+++ b/tests/cli/commands/test_upload.py
@@ -447,6 +447,42 @@ def test_existing_entity_different_content(
         stdout=result.stdout, stderr=result.stderr
     )
 
+    # Now let's check we get the same result if setting `quiet=False` and
+    # `auto_confirm=True` and not providing other input, since the previous input
+    # (still) equals the general defaults.
+    # Here would should get some outputs, however.
+    result = cli.invoke(
+        APP,
+        f"upload --file {tmp_path / 'Person.json'} --auto-confirm",
+    )
+    assert result.exit_code == 0, CLI_RESULT_FAIL_MESSAGE.format(
+        stdout=result.stdout, stderr=result.stderr
+    )
+    assert not result.stderr, CLI_RESULT_FAIL_MESSAGE.format(
+        stdout=result.stdout, stderr=result.stderr
+    )
+    assert result.stdout, CLI_RESULT_FAIL_MESSAGE.format(
+        stdout=result.stdout, stderr=result.stderr
+    )
+    # Ensure no confirmations or prompts are in the output
+    assert (
+        "You cannot overwrite external existing entities. Do you wish to upload the "
+        "new entity with an updated version number?" not in result.stdout
+    ), CLI_RESULT_FAIL_MESSAGE.format(stdout=result.stdout, stderr=result.stderr)
+    assert (
+        "These entities will be uploaded. Do you want to continue?" not in result.stdout
+    ), CLI_RESULT_FAIL_MESSAGE.format(stdout=result.stdout, stderr=result.stderr)
+    assert (
+        "Please enter the new version" not in result.stdout
+    ), CLI_RESULT_FAIL_MESSAGE.format(stdout=result.stdout, stderr=result.stderr)
+    # Ensure specific `quiet=False` and `auto_confirm=True` outputs are in the output
+    assert (
+        "Info: Updating the to-be-uploaded entity to version:" in result.stdout
+    ), CLI_RESULT_FAIL_MESSAGE.format(stdout=result.stdout, stderr=result.stderr)
+    assert "Entities to upload" in result.stdout, CLI_RESULT_FAIL_MESSAGE.format(
+        stdout=result.stdout, stderr=result.stderr
+    )
+
     # Now, let's check we update the version if wanting to.
     # Use custom version.
 


### PR DESCRIPTION
Closes #119

The `--auto-confirm` option differs from `--quiet`, in that messages are still printed to the console, but all of the prompts and confirmations are skipped and defaults are used instead.
`--quiet` does the same thing, effectively, but does not print anything to the console - other than error messages, these cannot be avoided.

As this is based on #120, that PR needs to be merged prior to this one.

---

To do:
- [x] Merge #120 
- [x] Add tests for the new option.