### PR TITLE
Add `--strict` option to CLI

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Upload coverage
         if: github.repository_owner == 'SINTEF'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
@@ -185,7 +185,7 @@ jobs:
 
       - name: Upload coverage
         if: github.repository_owner == 'SINTEF'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/entities_service/cli/commands/upload.py
+++ b/entities_service/cli/commands/upload.py
@@ -143,6 +143,20 @@ def upload(
             show_default=False,
         ),
     ] = False,
+    strict: Annotated[
+        bool,
+        typer.Option(
+            "--strict",
+            help=(
+                "Strict validation of entities. This means the command will fail "
+                "during the validation process, if an external entity already exists "
+                "and the two entities are not equal. This option is only relevant if "
+                "'--no-external-calls' is not provided. If both '--no-external-calls'"
+                " and this options is provided, an error will be emitted."
+            ),
+            show_default=True,
+        ),
+    ] = False,
 ) -> None:
     """Upload (local) entities to a remote location."""
     # Ensure the user is logged in
@@ -159,6 +173,7 @@ def upload(
         no_external_calls=False,
         return_full_info=True,
         verbose=False,
+        strict=strict,
     )
 
     # Sanity check - done only for typing to be caught by mypy and testing


### PR DESCRIPTION
Closes #129 

Adds the `--strict` flag option to the CLI commands `upload` and `validate`.

This is centered around the `validate` command. If `--strict` is supplied, if an entity already exists externally and differs in content, validation will fail for that entity.
Therefore, `--strict` is also mutually exclusive with `--no-external-calls`. If both are supplied an error will be raised.

---

Note, this PR also updates the [codecov-action](https://github.com/codecov/codecov-action) to v4.