### PR TITLE
Ensure `last_namespace` is updated iteratively

### DIFF
--- a/entities_service/cli/commands/upload.py
+++ b/entities_service/cli/commands/upload.py
@@ -371,6 +371,8 @@ def upload(
                     f"{name} (v{version})",
                 )
 
+                last_namespace = namespace
+
             print(
                 "",
                 Rule(title="[bold green]Entities to upload[/bold green]"),


### PR DESCRIPTION
Fixes #149 

This was extremely simple fix, and a bit of a blunder in the code to not have included this line.

The new output looks like this, with a line only between groupings of same namespaced entities:
![image](https://github.com/SINTEF/entities-service/assets/43357585/89fced36-9d5d-4ac2-b7a5-adec08d467b9)
