### PR TITLE
Drop safety in favor of pip-audit

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -30,18 +30,27 @@ jobs:
       # Build documentation
       run_build_docs: false
 
-  safety:
-    name: Safety
+  pip-audit:
+    name: pip-audit
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout ${{ github.repository }}
       uses: actions/checkout@v4
 
-    - name: Run Safety CLI to check for vulnerabilities
-      uses: pyupio/safety-action@v1
+    - name: Setup Python 3.10
+      uses: actions/setup-python@v5
       with:
-        api-key: ${{ secrets.SAFETY_API_TOKEN }}
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install -U pip
+        pip install -U setuptools wheel
+        pip install -U -e .[dev,server]
+
+    - name: Run pip-audit
+      uses: pypa/gh-action-pip-audit@v1.1.0
 
   docker:
     name: Docker


### PR DESCRIPTION
Similarly to what has been done in all the OTE repositories, `safety` will be replaced by `pip-audit`.
This is due to a requirement by Safety to create a user.

## AI Summary

This pull request updates the CI workflow to replace the `Safety` job with a `pip-audit` job for dependency vulnerability checks. The new job uses a different tool and includes setup steps to ensure compatibility with the updated process.

### CI Workflow Updates:
* Replaced the `Safety` job with a `pip-audit` job in `.github/workflows/ci_tests.yml`. This includes switching from the `pyupio/safety-action` to the `pypa/gh-action-pip-audit` for vulnerability scanning.
* Added a step to set up Python 3.10 using `actions/setup-python@v5`.
* Introduced a new step to install dependencies, including upgrading `pip`, `setuptools`, and `wheel`, and installing the project in development mode with extras `[dev,server]`.